### PR TITLE
Pull the first and last names from the identity provider

### DIFF
--- a/lib/omniauth/strategies/nyulibraries.rb
+++ b/lib/omniauth/strategies/nyulibraries.rb
@@ -21,8 +21,8 @@ module OmniAuth
           name: raw_info["username"],
           nickname: raw_info["username"],
           email: raw_info["email"],
-          first_name: last_name,
-          last_name: first_name
+          last_name: last_name,
+          first_name: first_name
         }
       end
       extra do
@@ -38,14 +38,17 @@ module OmniAuth
         @raw_info ||= response.parsed
       end
 
+      # Get the provider's identity
       def provider_identity
-        @provider_identity ||= raw_data["identities"].find {|id| id["provider"] == raw_data["provider"]}
+        @provider_identity ||= raw_info["identities"].find {|id| id["provider"] == raw_info["provider"]}
       end
 
+      # Extract Last Name from identity
       def last_name
         @last_name ||= provider_identity["properties"]["last_name"] rescue nil
       end
 
+      # Extract First Name from identity
       def first_name
         @first_name ||= provider_identity["properties"]["first_name"] rescue nil
       end

--- a/spec/omniauth/strategies/nyulibraries_spec.rb
+++ b/spec/omniauth/strategies/nyulibraries_spec.rb
@@ -9,10 +9,8 @@ module OmniAuth
               "username" => "username",
               "email" => "email",
               "provider" => "provider",
-              "identities" => "identities",
-              "institution_code" => "institution_code",
-              "first_name" => "first_name",
-              "last_name" => "last_name"
+              "identities" => [{ "provider" => "provider", "properties" => {"last_name"=>"last_name","first_name"=>"first_name"}}],
+              "institution_code" => "institution_code"
             })
         end
         let(:access_token) { double('access_token', :get => response) }
@@ -74,7 +72,7 @@ module OmniAuth
           it { should be_a(Hash) }
           it { should eq({
               provider: "provider",
-              identities: "identities",
+              identities: [{ "provider" => "provider", "properties" => {"last_name"=>"last_name","first_name"=>"first_name"}}],
               institution_code: "institution_code"
             })}
         end
@@ -86,10 +84,8 @@ module OmniAuth
               "username" => "username",
               "email" => "email",
               "provider" => "provider",
-              "identities" => "identities",
-              "institution_code" => "institution_code",
-              "first_name" => "first_name",
-              "last_name" => "last_name"
+              "identities" => [{ "provider" => "provider", "properties" => {"last_name"=>"last_name","first_name"=>"first_name"}}],
+              "institution_code" => "institution_code"
             })}
         end
       end


### PR DESCRIPTION
@hab278 So the user from login doesn't have a user level firstname and lastname, it's populated by the identities, could be gotten from Shib, maybe from Aleph, Facebook, etc.

So in this strategy we can extract the name from the identity that belongs to this user's provider and put it in the top level for client apps.
