### PR TITLE
Feature/configurable oauth host

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Where `YOUR_APP_KEY` and `YOUR_APP_SECRET` are the __Application Id__ and __Appl
 
 ## Configuration
 
-By default, `omniauth-nyulibraries` authenticates from https://dev.login.library.nyu.edu, and uses "/oauth/authorize" as the authorization path. If you want to authenticate from a different instance of Login,
+By default, `omniauth-nyulibraries` authenticates from https://login.library.nyu.edu, and uses "/oauth/authorize" as the authorization path. If you want to authenticate from a different instance of Login,
 use the `:client_options` option when you add the provider to your app.
 
 ```ruby

--- a/lib/omniauth/strategies/nyulibraries.rb
+++ b/lib/omniauth/strategies/nyulibraries.rb
@@ -8,7 +8,7 @@ module OmniAuth
       option :name, :nyulibraries
 
       option :client_options, {
-        site: (ENV['LOGIN_APP_HOST'] || "https://dev.login.library.nyu.edu"),
+        site: (ENV['LOGIN_URL'] || "https://dev.login.library.nyu.edu"),
         authorize_path: "/oauth/authorize"
       }
 

--- a/lib/omniauth/strategies/nyulibraries.rb
+++ b/lib/omniauth/strategies/nyulibraries.rb
@@ -8,7 +8,7 @@ module OmniAuth
       option :name, :nyulibraries
 
       option :client_options, {
-        site: "https://dev.login.library.nyu.edu",
+        site: (ENV['LOGIN_APP_HOST'] || "https://dev.login.library.nyu.edu"),
         authorize_path: "/oauth/authorize"
       }
 

--- a/lib/omniauth/strategies/nyulibraries.rb
+++ b/lib/omniauth/strategies/nyulibraries.rb
@@ -8,7 +8,7 @@ module OmniAuth
       option :name, :nyulibraries
 
       option :client_options, {
-        site: (ENV['LOGIN_URL'] || "https://dev.login.library.nyu.edu"),
+        site: (ENV['LOGIN_URL'] || "https://login.library.nyu.edu"),
         authorize_path: "/oauth/authorize"
       }
 

--- a/spec/omniauth/strategies/nyulibraries_spec.rb
+++ b/spec/omniauth/strategies/nyulibraries_spec.rb
@@ -37,7 +37,7 @@ module OmniAuth
             it { should be_a(Hash) }
             it { should_not be_empty }
             context "when default" do
-              it { should eq({ "site" => "https://dev.login.library.nyu.edu",
+              it { should eq({ "site" => "https://login.library.nyu.edu",
                 "authorize_path" => "/oauth/authorize" }) }
             end
             context "when production" do
@@ -105,7 +105,7 @@ module OmniAuth
         describe '/auth/nyulibraries' do
           before(:each){ get '/auth/nyulibraries' }
           let(:login_authorization) do
-            "https://dev.login.library.nyu.edu/oauth/authorize?client_id=#{application_id}"+
+            "https://login.library.nyu.edu/oauth/authorize?client_id=#{application_id}"+
               "&redirect_uri=http%3A%2F%2Fexample.org%2Fauth%2Fnyulibraries%2Fcallback&"+
                 "response_type=code&"
           end


### PR DESCRIPTION
If client's figs environment is loaded before the bundle then they can use `ENV['LOGIN_URL']` to drive their login url, otherwise default to `login.library.nyu.edu`.